### PR TITLE
fix(handlers): correct deleteProperty trap of proxy handler

### DIFF
--- a/src/handlers.js
+++ b/src/handlers.js
@@ -28,7 +28,7 @@ function createSetter (target, key, value, receiver) {
 function createDeleteProperty (target, key) {
   const hadKey = hasOwn(target, key)
   const oldValue = target[key]
-  const result = Reflect.set(target, key, value, receiver)
+  const result = Reflect.deleteProperty(target, key)
 
   if (hadKey) {
     trigger(target, 'delete', key)


### PR DESCRIPTION
In deleteProperty trap, I think using Reflect.deleteProperty API is more appropriate.